### PR TITLE
MNT: update dependencies in line with textual 0.12.1 pyproject.toml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ outputs:
         - rich >12.6
         - markdown-it-py >=2.1.0,<3
         - typing-extensions >=4,<5
-        - importlib-metadata >=4.11.3,<5
+        - importlib-metadata >=4.11.3,<4.12
     test:
       imports:
         - textual
@@ -53,9 +53,10 @@ outputs:
       run:
         - python >=3.7,<4
         - {{ pin_subpackage('textual', exact=True) }}
-        - aiohttp
-        - click
-        - msgpack-python
+        - aiohttp >=3.8.1
+        - click >=8.1.2
+        - msgpack-python >=1.0.3
+        - mkdocs-exclude >=1.0.2,<1.1
     test:
       commands:
         - textual --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f826b422e39e4ca188307336f6a4f4b0a89834dab2628430b613084c70799dfd
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 
@@ -26,9 +26,9 @@ outputs:
         - pip
       run:
         - python >=3.7,<4
-        - rich >=12.6,<13
+        - rich >12.6
+        - markdown-it-py >=2.1.0,<3
         - typing-extensions >=4,<5
-        - nanoid >=2.0,<3
         - importlib-metadata >=4.11.3,<5
     test:
       imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Howdy, this PR brings the textual conda dependencies in line with the 0.12.1 textual pypi dependencies - as it stands, it is possible to create an invalid environment with conda, with the result that runtime errors occur on attempts to import textual (this is a repeat of #9)
