### PR TITLE
Add linkify-it-py as explicit dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - python >=3.8.1,<4.0.0
     - markdown-it-py >=2.1.0
     - linkify-it-py >=1,<3
+    - mdit-py-plugins
     - rich >=13.3.3
     - typing-extensions >=4.4.0,<5.0.0
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -24,6 +24,7 @@ requirements:
     - platformdirs >=3.6.0,<5
     - python >=3.8.1,<4.0.0
     - markdown-it-py >=2.1.0
+    - linkify-it-py >=1,<3
     - rich >=13.3.3
     - typing-extensions >=4.4.0,<5.0.0
   run_constrained:


### PR DESCRIPTION
The PyPi version of `textual` lists `linkify-it-py` as an extra dependency of `markdown-it-py`, but since the [extra-component] syntax used by pip is not supported by conda, this dependency was missing in the conda-forge recipe. See https://github.com/Textualize/textual/blob/main/pyproject.toml#L44.

This was causing issues with the (bio)conda recipe of a downstream packages that relied on `textual` and `trogon` (see https://github.com/nf-core/tools/issues/3257).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
